### PR TITLE
Revamp landing page as login

### DIFF
--- a/src/server/nrp-site/auth.js
+++ b/src/server/nrp-site/auth.js
@@ -17,7 +17,11 @@ router.get(
   "/login",
   (req, res, next) => {
     if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
-      return res.redirect("/");
+      return res.redirect("/admin-panel");
+    }
+
+    if (req.session) {
+      req.session.returnTo = "/admin-panel";
     }
 
     next();
@@ -26,7 +30,7 @@ router.get(
     scope: "openid email profile"
   }),
   (req, res) => {
-    res.redirect("/");
+    res.redirect("/admin-panel");
   }
 );
 
@@ -44,7 +48,7 @@ router.get("/callback", (req, res, next) => {
       }
       const returnTo = req.session.returnTo;
       delete req.session.returnTo;
-      res.redirect(returnTo || "/");
+      res.redirect(returnTo || "/admin-panel");
     });
   })(req, res, next);
 });

--- a/src/server/nrp-site/index.js
+++ b/src/server/nrp-site/index.js
@@ -108,6 +108,9 @@ app.get("/admin-panel", secured, (req, res, next) => {
 });
 
 app.get("/", (req, res) => {
+  if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
+    return res.redirect("/admin-panel");
+  }
   res.render("index", { title: "Home" });
 });
 

--- a/src/server/nrp-site/public/style.css
+++ b/src/server/nrp-site/public/style.css
@@ -1,5 +1,124 @@
 /* public/style.css */
 
+:root {
+  --bg-dark: #0e0e0e;
+  --bg-mid: #1c1c1c;
+  --bg-light: #3a3a3a;
+  --card-surface: rgba(255, 255, 255, 0.05);
+  --card-border: rgba(255, 255, 255, 0.12);
+  --text-primary: #f4f4f4;
+  --text-secondary: #c8c8c8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
 body {
-  background: rgb(177, 177, 177);
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background: radial-gradient(circle at 20% 20%, var(--bg-light), var(--bg-mid) 45%, var(--bg-dark));
+  color: var(--text-primary);
+}
+
+#root {
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.login-page {
+  width: 100%;
+  max-width: 520px;
+}
+
+.login-card {
+  background: var(--card-surface);
+  border: 1px solid var(--card-border);
+  border-radius: 26px;
+  padding: 3rem;
+  text-align: center;
+  backdrop-filter: blur(14px);
+  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.login-logo {
+  margin: 0;
+  font-size: 3rem;
+  letter-spacing: 0.75rem;
+  text-transform: uppercase;
+}
+
+.login-title {
+  margin: 0;
+  font-weight: 500;
+  letter-spacing: 0.14rem;
+}
+
+.login-details {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.login-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  padding: 0.95rem 2.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f3f3f3, #cfcfcf);
+  color: #101010;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.login-button:hover,
+.login-button:focus {
+  background: linear-gradient(135deg, #ffffff, #dcdcdc);
+  transform: translateY(-3px);
+  box-shadow: 0 24px 46px rgba(0, 0, 0, 0.45);
+}
+
+.login-button:focus {
+  outline: 2px solid #f3f3f3;
+  outline-offset: 4px;
+}
+
+@media (max-width: 520px) {
+  #root {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .login-card {
+    padding: 2.5rem 1.75rem;
+    border-radius: 22px;
+  }
+
+  .login-logo {
+    font-size: 2.4rem;
+    letter-spacing: 0.55rem;
+  }
+
+  .login-button {
+    width: 100%;
+    padding: 0.9rem 1.75rem;
+  }
 }

--- a/src/server/nrp-site/views/index.pug
+++ b/src/server/nrp-site/views/index.pug
@@ -1,16 +1,9 @@
 extends layout
 
 block layout-content
-  div.View
-    h1.Banner GNA
-    div.Message
-      div.Title
-        h1 GeoFS NRP Admin Site
-      span.Details For High Command officers and centralized governing members
-      div.NavButtons
-      if isAuthenticated
-        a(href="/admin-panel")
-          div.NavButton Just dive in!
-      else
-        a(href="/login")
-          div.NavButton Log in
+  main.login-page
+    section.login-card
+      h1.login-logo GNA
+      h2.login-title GeoFS NRP Admin Site
+      a.login-button(href="/login") Log in
+      p.login-details For High Command officers and centralized governing members


### PR DESCRIPTION
## Summary
- restyled the home view into a centered login card that keeps the existing copy
- refreshed the public stylesheet with a monochrome, modern layout for the login experience
- redirected authenticated flows so logging in lands directly on the admin panel

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c88164fef48323afbd657155dd0a55