### PR TITLE
Integrate standalone dashboard into admin panel

### DIFF
--- a/src/server/nrp-site/views/admin-panel.pug
+++ b/src/server/nrp-site/views/admin-panel.pug
@@ -1,11 +1,1573 @@
 extends layout
 
+block head
+  style.
+    :root {
+        --bg-dark: #0d1117;
+        --bg-card: #161b22;
+        --border: #30363d;
+        --text-primary: #c9d1d9;
+        --text-secondary: #8b949e;
+        --accent-blue: #58a6ff;
+        --accent-green: #2ea043;
+        --accent-red: #da3633;
+        --accent-yellow: #d29922;
+        --btn-primary: #238636;
+        --btn-secondary: #30363d;
+        --sidebar-width: 280px;
+        --topbar-height: 60px;
+    }
+
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    }
+
+    body {
+        background-color: var(--bg-dark);
+        color: var(--text-primary);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+    }
+
+    /* Topbar Styles */
+    .topbar {
+        background-color: var(--bg-card);
+        height: var(--topbar-height);
+        display: flex;
+        align-items: center;
+        padding: 0 16px;
+        position: fixed;
+        top: 0;
+        left: var(--sidebar-width);
+        right: 0;
+        z-index: 100;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .topbar-content {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+    }
+
+    .tabs {
+        display: flex;
+        gap: 8px;
+    }
+
+    .tab {
+        padding: 8px 16px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 500;
+        transition: all 0.2s;
+    }
+
+    .tab:hover {
+        background-color: var(--btn-secondary);
+    }
+
+    .tab.active {
+        background-color: rgba(88, 166, 255, 0.15);
+        color: var(--accent-blue);
+    }
+
+    .user-menu {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-shrink: 0;
+    }
+
+    .sign-out-btn {
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid var(--border);
+        background-color: rgba(218, 54, 51, 0.1);
+        border-color: rgba(238, 45, 41, 0.1) ;
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        transition: all 0.2s;
+    }
+
+    /* Sidebar Styles */
+    .sidebar {
+        width: var(--sidebar-width);
+        background-color: var(--bg-card);
+        height: 100vh;
+        position: fixed;
+        top: 0;
+        left: 0;
+        transition: transform 0.3s ease;
+        z-index: 90;
+        overflow-y: auto;
+        border-right: 1px solid var(--border);
+    }
+
+    .sidebar-content {
+        padding: 20px;
+        padding-top: calc(20px + var(--topbar-height));
+    }
+
+    .force-info {
+        margin-bottom: 24px;
+    }
+
+    .force-header {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        margin-bottom: 16px;
+    }
+
+    .force-logo {
+        width: 60px;
+        height: 60px;
+        border-radius: 8px;
+        background-color: var(--btn-secondary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        cursor: pointer;
+        position: relative;
+        overflow: hidden;
+        flex-shrink: 0;
+        transition: all 0.2s ease;
+    }
+
+    .force-logo:hover {
+        transform: scale(1.05);
+        box-shadow: 0 0 0 2px var(--accent-blue);
+    }
+
+    .force-logo img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .force-logo-placeholder {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--text-secondary);
+        position: relative;
+    }
+
+    .edit-icon {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        background: rgba(0, 0, 0, 0.7);
+        border-radius: 50%;
+        width: 20px;
+        height: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 12px;
+        opacity: 0;
+        transition: opacity 0.2s;
+    }
+
+    .force-logo:hover .edit-icon {
+        opacity: 1;
+    }
+
+    .force-name-container {
+        flex: 1;
+    }
+
+    .force-name {
+        font-size: 18px;
+        font-weight: 600;
+        margin-bottom: 4px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .force-stats {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-bottom: 16px;
+    }
+
+    .stat-card {
+        background-color: rgba(48, 54, 61, 0.3);
+        border-radius: 6px;
+        padding: 12px;
+        cursor: pointer;
+        transition: background-color 0.2s;
+    }
+
+    .stat-card:hover {
+        background-color: rgba(48, 54, 61, 0.5);
+    }
+
+    .stat-value {
+        font-size: 24px;
+        font-weight: 600;
+        margin-bottom: 4px;
+    }
+
+    .stat-label {
+        font-size: 12px;
+        color: var(--text-secondary);
+        text-transform: uppercase;
+    }
+
+    .force-details {
+        margin-top: 16px;
+    }
+
+    .detail-item {
+        display: flex;
+        justify-content: space-between;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .detail-label {
+        color: var(--text-secondary);
+    }
+
+    .detail-value {
+        font-weight: 500;
+        text-align: right;
+        max-width: 60%;
+        word-break: break-word;
+    }
+
+    .edit-details-btn {
+        width: 100%;
+        padding: 8px;
+        background: none;
+        border: 1px dashed var(--border);
+        color: var(--text-secondary);
+        border-radius: 4px;
+        cursor: pointer;
+        margin-top: 12px;
+        font-size: 14px;
+    }
+
+    .edit-details-btn:hover {
+        background-color: var(--btn-secondary);
+    }
+
+    /* Main Content */
+    .main-content {
+        flex: 1;
+        margin-left: var(--sidebar-width);
+        padding: 24px;
+        margin-top: var(--topbar-height);
+        transition: margin-left 0.3s ease;
+    }
+
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 24px;
+    }
+
+    .section-title {
+        font-size: 24px;
+        font-weight: 500;
+    }
+
+    /* Card Styles */
+    .card {
+        background-color: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 16px;
+        margin-bottom: 16px;
+    }
+
+    .card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+    }
+
+    .card-title {
+        font-size: 18px;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .card-actions {
+        display: flex;
+        gap: 8px;
+    }
+
+    .btn {
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid var(--border);
+        background-color: var(--btn-secondary);
+        color: var(--text-primary);
+        cursor: pointer;
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        transition: all 0.2s;
+    }
+
+    .btn:hover {
+        background-color: #383e47;
+    }
+
+    .btn-primary {
+        background-color: var(--btn-primary);
+        border-color: var(--btn-primary);
+    }
+
+    .btn-primary:hover {
+        background-color: #2ea043;
+    }
+
+    .btn-danger {
+        background-color: var(--btn-secondary);
+        border-color: var(--border);
+    }
+
+    .btn-danger:hover {
+        background-color: rgba(218, 54, 51, 0.1);
+        color: var(--accent-red);
+    }
+
+    .card-content {
+        color: var(--text-secondary);
+        font-size: 14px;
+        line-height: 1.5;
+    }
+
+    .card-content p {
+        margin-bottom: 8px;
+    }
+
+    .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        display: inline-block;
+    }
+
+    .status-green { background-color: var(--accent-green); }
+    .status-yellow { background-color: var(--accent-yellow); }
+    .status-red { background-color: var(--accent-red); }
+
+    /* Grid Layout */
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+        gap: 24px;
+    }
+
+    /* Hidden class */
+    .hidden {
+        display: none;
+    }
+
+    .form-group {
+        margin-bottom: 16px;
+    }
+
+    .form-label {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 14px;
+    }
+
+    .form-input {
+        width: 100%;
+        padding: 8px 12px;
+        background-color: var(--bg-dark);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        color: var(--text-primary);
+        font-size: 14px;
+    }
+
+    .form-row {
+        display: flex;
+        gap: 16px;
+    }
+
+    .form-col {
+        flex: 1;
+    }
+
+    .checkbox-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        margin-top: 8px;
+    }
+
+    .checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .checkbox-item input {
+        margin-right: 4px;
+    }
+
+    /* File input styling */
+    .file-input-wrapper {
+        position: relative;
+        overflow: hidden;
+        display: inline-block;
+    }
+
+    .file-input-wrapper input[type=file] {
+        position: absolute;
+        left: 0;
+        top: 0;
+        opacity: 0;
+        width: 100%;
+        height: 100%;
+        cursor: pointer;
+    }
+
+    /* Modal Styles */
+    .modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.7);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transition: all 0.3s ease;
+    }
+
+    .modal.show {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .modal-content {
+        background-color: var(--bg-card);
+        border-radius: 8px;
+        width: 90%;
+        max-width: 600px;
+        max-height: 90vh;
+        overflow-y: auto;
+        border: 1px solid var(--border);
+        transform: translateY(-20px);
+        transition: transform 0.3s ease;
+    }
+
+    .modal.show .modal-content {
+        transform: translateY(0);
+    }
+
+    .modal-header {
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .modal-title {
+        font-size: 20px;
+        font-weight: 500;
+    }
+
+    .modal-close {
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        font-size: 24px;
+        cursor: pointer;
+        width: 32px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+        transition: all 0.2s;
+    }
+
+    .modal-close:hover {
+        background-color: var(--btn-secondary);
+        color: var(--text-primary);
+    }
+
+    .modal-body {
+        padding: 24px;
+    }
+
+    .modal-footer {
+        padding: 16px 24px;
+        border-top: 1px solid var(--border);
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+    }
+
+    /* Base List Styles */
+    .base-list, .ship-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 20px;
+        margin-top: 20px;
+    }
+
+    .base-card, .ship-card {
+        background-color: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 16px;
+        position: relative;
+        transition: transform 0.2s;
+    }
+
+    .base-card:hover, .ship-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    }
+
+    .base-card-header, .ship-card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+    }
+
+    .base-name, .ship-name {
+        font-size: 18px;
+        font-weight: 500;
+        color: var(--accent-blue);
+    }
+
+    .base-actions, .ship-actions {
+        display: flex;
+        gap: 8px;
+    }
+
+    .base-details, .ship-details {
+        margin-top: 12px;
+    }
+
+    .base-detail, .ship-detail {
+        display: flex;
+        justify-content: space-between;
+        padding: 6px 0;
+        border-bottom: 1px solid rgba(48, 54, 61, 0.5);
+    }
+
+    .base-detail:last-child, .ship-detail:last-child {
+        border-bottom: none;
+    }
+
+    .base-detail-label, .ship-detail-label {
+        color: var(--text-secondary);
+    }
+
+    .base-detail-value, .ship-detail-value {
+        font-weight: 500;
+    }
+
+    .add-base-btn, .add-ship-btn {
+        background-color: var(--btn-primary);
+        border: none;
+        color: white;
+        padding: 8px 16px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        transition: background-color 0.2s;
+    }
+
+    .add-base-btn:hover, .add-ship-btn:hover {
+        background-color: #2ea043;
+    }
+
+    .empty-state {
+        text-align: center;
+        padding: 40px 20px;
+        color: var(--text-secondary);
+        grid-column: 1 / -1;
+    }
+
+    .empty-state-icon {
+        font-size: 48px;
+        margin-bottom: 16px;
+        opacity: 0.5;
+    }
+
+    /* Ship Class Badge */
+    .ship-class-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 500;
+        background-color: rgba(88, 166, 255, 0.15);
+        color: var(--accent-blue);
+    }
+
+    /* Responsive */
+    @media (max-width: 992px) {
+        .sidebar {
+            transform: translateX(-100%);
+        }
+
+        .sidebar.active {
+            transform: translateX(0);
+        }
+
+        .main-content,
+        .topbar {
+            margin-left: 0;
+        }
+
+        .topbar {
+            left: 0;
+        }
+    }
+
+    @media (max-width: 768px) {
+        .grid {
+            grid-template-columns: 1fr;
+        }
+
+        .form-row {
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .container {
+            padding: 16px;
+        }
+
+        .force-header {
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+        }
+
+        .force-name-container {
+            text-align: center;
+        }
+
+        .topbar {
+            padding: 0 12px;
+        }
+
+        .user-menu {
+            gap: 8px;
+        }
+
+        .sidebar-content {
+            padding-top: 20px;
+        }
+
+        .tabs {
+            flex-wrap: wrap;
+        }
+
+        .base-list, .ship-list {
+            grid-template-columns: 1fr;
+        }
+    }
+
 block layout-content
-  div.View
-    h1.Banner GNA
-    div.Message
-      div.Title
-        h1 Admin Panel
-      div.NavButtons
-      a(href="/logout")
-        div.NavButton Log out
+  aside.sidebar#sidebar
+    .sidebar-content
+      .force-info
+        .force-header
+          .force-logo#force-logo
+            .force-logo-placeholder
+              | 🇺🇸
+              .edit-icon ✏️
+            input#logo-upload.hidden(type="file", accept="image/*")
+          .force-name-container
+            h2.force-name United States Navy
+        .force-stats
+          .stat-card(data-stat="ships")
+            .stat-value#ships-count 293
+            .stat-label Ships
+          .stat-card(data-stat="aircraft")
+            .stat-value#aircraft-count 3,700
+            .stat-label Aircraft
+          .stat-card(data-stat="fleets")
+            .stat-value#fleets-count 74
+            .stat-label Fleets
+          .stat-card(data-stat="personnel")
+            .stat-value#personnel-count 332K
+            .stat-label Personnel
+        .force-details
+          .detail-item
+            span.detail-label Commander
+            span.detail-value#commander-value Adm. Michael Gilday
+          .detail-item
+            span.detail-label Established
+            span.detail-value#established-value 1775
+          .detail-item
+            span.detail-label Headquarters
+            span.detail-value#headquarters-value Pentagon, VA
+          .detail-item
+            span.detail-label Motto
+            span.detail-value#motto-value "Non sibi sed patriae"
+          button.edit-details-btn#edit-details-btn ✏️ Edit Force Details
+  header.topbar
+    .topbar-content
+      .tabs
+        .tab(data-tab="bases") Bases
+        .tab.active(data-tab="ships") Ships
+        .tab(data-tab="fleets") Fleets
+      .user-menu
+        button.sign-out-btn(type="button")
+          span
+          | Sign Out
+  main.main-content
+    #bases-content.hidden
+      .section-header
+        h2.section-title Naval Bases
+        button.add-base-btn#add-base-btn(type="button")
+          span +
+          |  Add Base
+      .base-list#base-list
+        .base-card
+          .base-card-header
+            h3.base-name Norfolk Naval Station
+            .base-actions
+              button.btn.btn-edit(type="button", data-id="1") ✏️
+              button.btn.btn-danger(type="button", data-id="1") 🗑️
+          .base-details
+            .base-detail
+              span.base-detail-label Location:
+              span.base-detail-value Virginia, USA
+            .base-detail
+              span.base-detail-label Capacity:
+              span.base-detail-value 12,000 personnel
+            .base-detail
+              span.base-detail-label Status:
+              span.base-detail-value.status
+                span.status-dot.status-green
+                |  Operational
+        .base-card
+          .base-card-header
+            h3.base-name Pearl Harbor
+            .base-actions
+              button.btn.btn-edit(type="button", data-id="2") ✏️
+              button.btn.btn-danger(type="button", data-id="2") 🗑️
+          .base-details
+            .base-detail
+              span.base-detail-label Location:
+              span.base-detail-value Hawaii, USA
+            .base-detail
+              span.base-detail-label Capacity:
+              span.base-detail-value 15,000 personnel
+            .base-detail
+              span.base-detail-label Status:
+              span.base-detail-value.status
+                span.status-dot.status-green
+                |  Operational
+        .base-card
+          .base-card-header
+            h3.base-name Guantanamo Bay
+            .base-actions
+              button.btn.btn-edit(type="button", data-id="3") ✏️
+              button.btn.btn-danger(type="button", data-id="3") 🗑️
+          .base-details
+            .base-detail
+              span.base-detail-label Location:
+              span.base-detail-value Cuba
+            .base-detail
+              span.base-detail-label Capacity:
+              span.base-detail-value 8,000 personnel
+            .base-detail
+              span.base-detail-label Status:
+              span.base-detail-value.status
+                span.status-dot.status-yellow
+                |  Limited Operations
+    #ships-content
+      .section-header
+        h2.section-title Naval Ships
+        button.add-ship-btn#add-ship-btn(type="button")
+          span +
+          |  Add Ship
+      .ship-list#ship-list
+        .ship-card
+          .ship-card-header
+            h3.ship-name USS Gerald R. Ford
+            .ship-actions
+              button.btn.btn-edit(type="button", data-id="1") ✏️
+              button.btn.btn-danger(type="button", data-id="1") 🗑️
+          .ship-details
+            .ship-detail
+              span.ship-detail-label Class:
+              span.ship-detail-value
+                span.ship-class-badge Aircraft Carrier
+            .ship-detail
+              span.ship-detail-label Hull Number:
+              span.ship-detail-value CVN-78
+            .ship-detail
+              span.ship-detail-label Status:
+              span.ship-detail-value.status
+                span.status-dot.status-green
+                |  Active
+        .ship-card
+          .ship-card-header
+            h3.ship-name USS Zumwalt
+            .ship-actions
+              button.btn.btn-edit(type="button", data-id="2") ✏️
+              button.btn.btn-danger(type="button", data-id="2") 🗑️
+          .ship-details
+            .ship-detail
+              span.ship-detail-label Class:
+              span.ship-detail-value
+                span.ship-class-badge Destroyer
+            .ship-detail
+              span.ship-detail-label Hull Number:
+              span.ship-detail-value DDG-1000
+            .ship-detail
+              span.ship-detail-label Status:
+              span.ship-detail-value.status
+                span.status-dot.status-green
+                |  Active
+        .ship-card
+          .ship-card-header
+            h3.ship-name USS Virginia
+            .ship-actions
+              button.btn.btn-edit(type="button", data-id="3") ✏️
+              button.btn.btn-danger(type="button", data-id="3") 🗑️
+          .ship-details
+            .ship-detail
+              span.ship-detail-label Class:
+              span.ship-detail-value
+                span.ship-class-badge Submarine
+            .ship-detail
+              span.ship-detail-label Hull Number:
+              span.ship-detail-value SSN-774
+            .ship-detail
+              span.ship-detail-label Status:
+              span.ship-detail-value.status
+                span.status-dot.status-green
+                |  Active
+    #fleets-content.hidden
+      .section-header
+        h2.section-title Naval Fleets
+      .grid
+        .card
+          .card-header
+            h3.card-title Carrier Strike Group 12
+          .card-content
+            p Base: Norfolk Naval Station
+            p Composition:
+            p • CVN-78 USS Gerald R. Ford (Carrier)
+            p • DDG-116 USS Zumwalt (Destroyer)
+            p • SSN-785 USS Indiana (Submarine)
+            p + 5 more vessels
+            p
+              | Status:
+              = ' '
+              span.status
+                span.status-dot.status-green
+                |  Deployed - Mediterranean
+        .card
+          .card-header
+            h3.card-title Pacific Submarine Fleet
+          .card-content
+            p Base: Pearl Harbor
+            p Composition:
+            p • 12 Attack Submarines
+            p • 3 Ballistic Missile Submarines
+            p
+              | Status:
+              = ' '
+              span.status
+                span.status-dot.status-green
+                |  Operational
+  .modal#edit-force-modal
+    .modal-content
+      .modal-header
+        h3.modal-title Edit Force Details
+        button.modal-close#close-force-modal(type="button") ×
+      .modal-body
+        .form-group
+          label.form-label(for="edit-force-name") Force Name
+          input#edit-force-name.form-input(type="text", placeholder="Enter force name")
+        .form-row
+          .form-col
+            .form-group
+              label.form-label(for="edit-ships") Ships
+              input#edit-ships.form-input(type="text", placeholder="Number of ships")
+          .form-col
+            .form-group
+              label.form-label(for="edit-aircraft") Aircraft
+              input#edit-aircraft.form-input(type="text", placeholder="Number of aircraft")
+        .form-row
+          .form-col
+            .form-group
+              label.form-label(for="edit-fleets") Fleets
+              input#edit-fleets.form-input(type="text", placeholder="Number of fleets")
+          .form-col
+            .form-group
+              label.form-label(for="edit-personnel") Personnel
+              input#edit-personnel.form-input(type="text", placeholder="Number of personnel")
+        .form-group
+          label.form-label(for="edit-commander") Commander
+          input#edit-commander.form-input(type="text", placeholder="Commander name")
+        .form-row
+          .form-col
+            .form-group
+              label.form-label(for="edit-established") Established
+              input#edit-established.form-input(type="text", placeholder="Year established")
+          .form-col
+            .form-group
+              label.form-label(for="edit-headquarters") Headquarters
+              input#edit-headquarters.form-input(type="text", placeholder="Headquarters location")
+        .form-group
+          label.form-label(for="edit-motto") Motto
+          input#edit-motto.form-input(type="text", placeholder="Force motto")
+      .modal-footer
+        button.btn#cancel-force-details(type="button") Cancel
+        button.btn.btn-primary#save-force-details(type="button") Save Changes
+  .modal#base-modal
+    .modal-content
+      .modal-header
+        h3.modal-title#base-modal-title Add New Base
+        button.modal-close#close-base-modal(type="button") ×
+      .modal-body
+        input#base-id(type="hidden")
+        .form-group
+          label.form-label(for="base-name") Base Name
+          input#base-name.form-input(type="text", placeholder="Enter base name")
+        .form-group
+          label.form-label(for="base-location") Location
+          input#base-location.form-input(type="text", placeholder="Enter location")
+        .form-group
+          label.form-label(for="base-capacity") Capacity
+          input#base-capacity.form-input(type="text", placeholder="Enter capacity (e.g. 10,000 personnel)")
+        .form-group
+          label.form-label(for="base-status") Status
+          select#base-status.form-input
+            option(value="operational", selected) Operational
+            option(value="limited") Limited Operations
+            option(value="under-construction") Under Construction
+            option(value="decommissioned") Decommissioned
+      .modal-footer
+        button.btn#cancel-base(type="button") Cancel
+        button.btn.btn-primary#save-base(type="button") Save Base
+  .modal#ship-modal
+    .modal-content
+      .modal-header
+        h3.modal-title#ship-modal-title Add New Ship
+        button.modal-close#close-ship-modal(type="button") ×
+      .modal-body
+        input#ship-id(type="hidden")
+        .form-group
+          label.form-label(for="ship-name") Ship Name
+          input#ship-name.form-input(type="text", placeholder="Enter ship name")
+        .form-group
+          label.form-label(for="ship-class") Class
+          select#ship-class.form-input
+            option(value="Aircraft Carrier", selected) Aircraft Carrier
+            option(value="Destroyer") Destroyer
+            option(value="Cruiser") Cruiser
+            option(value="Submarine") Submarine
+            option(value="Amphibious") Amphibious
+            option(value="Frigate") Frigate
+            option(value="Patrol") Patrol
+        .form-group
+          label.form-label(for="ship-hull") Hull Number
+          input#ship-hull.form-input(type="text", placeholder="Enter hull number (e.g. CVN-78)")
+        .form-group
+          label.form-label(for="ship-status") Status
+          select#ship-status.form-input
+            option(value="active", selected) Active
+            option(value="reserve") Reserve
+            option(value="under-construction") Under Construction
+            option(value="decommissioned") Decommissioned
+      .modal-footer
+        button.btn#cancel-ship(type="button") Cancel
+        button.btn.btn-primary#save-ship(type="button") Save Ship
+  script.
+    const forceLogo = document.getElementById('force-logo');
+    const logoUpload = document.getElementById('logo-upload');
+
+    forceLogo.addEventListener('click', () => {
+        logoUpload.click();
+    });
+
+    logoUpload.addEventListener('change', function() {
+        if (this.files && this.files[0]) {
+            const reader = new FileReader();
+
+            reader.onload = function(e) {
+                forceLogo.innerHTML = `<img src="${e.target.result}" alt="Force Logo">`;
+            }
+
+            reader.readAsDataURL(this.files[0]);
+        }
+    });
+
+    const editDetailsBtn = document.getElementById('edit-details-btn');
+    const editForceModal = document.getElementById('edit-force-modal');
+    const closeForceModal = document.getElementById('close-force-modal');
+    const cancelForceDetails = document.getElementById('cancel-force-details');
+    const saveForceDetails = document.getElementById('save-force-details');
+
+    const signOutBtn = document.querySelector('.sign-out-btn');
+    if (signOutBtn) {
+        signOutBtn.addEventListener('click', () => {
+            window.location.href = '/logout';
+        });
+    }
+
+    editDetailsBtn.addEventListener('click', () => {
+        document.getElementById('edit-force-name').value = document.querySelector('.force-name').textContent.replace('🇺🇸 ', '');
+        document.getElementById('edit-ships').value = document.getElementById('ships-count').textContent;
+        document.getElementById('edit-aircraft').value = document.getElementById('aircraft-count').textContent;
+        document.getElementById('edit-fleets').value = document.getElementById('fleets-count').textContent;
+        document.getElementById('edit-personnel').value = document.getElementById('personnel-count').textContent;
+        document.getElementById('edit-commander').value = document.getElementById('commander-value').textContent;
+        document.getElementById('edit-established').value = document.getElementById('established-value').textContent;
+        document.getElementById('edit-headquarters').value = document.getElementById('headquarters-value').textContent;
+        document.getElementById('edit-motto').value = document.getElementById('motto-value').textContent.replace(/"/g, '');
+
+        editForceModal.classList.add('show');
+        document.body.style.overflow = 'hidden';
+    });
+
+    function closeModal(modal) {
+        modal.classList.remove('show');
+        document.body.style.overflow = '';
+    }
+
+    closeForceModal.addEventListener('click', () => closeModal(editForceModal));
+    cancelForceDetails.addEventListener('click', () => closeModal(editForceModal));
+
+    editForceModal.addEventListener('click', (e) => {
+        if (e.target === editForceModal) {
+            closeModal(editForceModal);
+        }
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && editForceModal.classList.contains('show')) {
+            closeModal(editForceModal);
+        }
+    });
+
+    saveForceDetails.addEventListener('click', () => {
+        document.querySelector('.force-name').innerHTML = `🇺🇸 ${document.getElementById('edit-force-name').value}`;
+        document.getElementById('ships-count').textContent = document.getElementById('edit-ships').value;
+        document.getElementById('aircraft-count').textContent = document.getElementById('edit-aircraft').value;
+        document.getElementById('fleets-count').textContent = document.getElementById('edit-fleets').value;
+        document.getElementById('personnel-count').textContent = document.getElementById('edit-personnel').value;
+        document.getElementById('commander-value').textContent = document.getElementById('edit-commander').value;
+        document.getElementById('established-value').textContent = document.getElementById('edit-established').value;
+        document.getElementById('headquarters-value').textContent = document.getElementById('edit-headquarters').value;
+        document.getElementById('motto-value').textContent = `"${document.getElementById('edit-motto').value}"`;
+
+        closeModal(editForceModal);
+    });
+
+    document.querySelectorAll('.tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.tab').forEach(t => {
+                t.classList.remove('active');
+            });
+
+            tab.classList.add('active');
+
+            document.getElementById('bases-content').classList.add('hidden');
+            document.getElementById('ships-content').classList.add('hidden');
+            document.getElementById('fleets-content').classList.add('hidden');
+
+            const tabName = tab.getAttribute('data-tab');
+            if (tabName) {
+                document.getElementById(`${tabName}-content`).classList.remove('hidden');
+            }
+        });
+    });
+
+    // Stat card click to edit
+    document.querySelectorAll('.stat-card').forEach(card => {
+        card.addEventListener('click', () => {
+            const statType = card.getAttribute('data-stat');
+            const statValue = card.querySelector('.stat-value').textContent;
+            const newValue = prompt(`Enter new value for ${statType}:`, statValue);
+
+            if (newValue !== null) {
+                card.querySelector('.stat-value').textContent = newValue;
+            }
+        });
+    });
+
+    let bases = [
+        {
+            id: 1,
+            name: "Norfolk Naval Station",
+            location: "Virginia, USA",
+            capacity: "12,000 personnel",
+            status: "operational"
+        },
+        {
+            id: 2,
+            name: "Pearl Harbor",
+            location: "Hawaii, USA",
+            capacity: "15,000 personnel",
+            status: "operational"
+        },
+        {
+            id: 3,
+            name: "Guantanamo Bay",
+            location: "Cuba",
+            capacity: "8,000 personnel",
+            status: "limited"
+        }
+    ];
+
+    let nextBaseId = 4;
+
+    // Base modal elements
+    const baseModal = document.getElementById('base-modal');
+    const closeBaseModal = document.getElementById('close-base-modal');
+    const cancelBase = document.getElementById('cancel-base');
+    const saveBase = document.getElementById('save-base');
+    const addBaseBtn = document.getElementById('add-base-btn');
+    const baseModalTitle = document.getElementById('base-modal-title');
+    const baseIdInput = document.getElementById('base-id');
+    const baseNameInput = document.getElementById('base-name');
+    const baseLocationInput = document.getElementById('base-location');
+    const baseCapacityInput = document.getElementById('base-capacity');
+    const baseStatusInput = document.getElementById('base-status');
+    const baseList = document.getElementById('base-list');
+
+    addBaseBtn.addEventListener('click', () => {
+        baseModalTitle.textContent = 'Add New Base';
+        baseIdInput.value = '';
+        baseNameInput.value = '';
+        baseLocationInput.value = '';
+        baseCapacityInput.value = '';
+        baseStatusInput.value = 'operational';
+
+        baseModal.classList.add('show');
+        document.body.style.overflow = 'hidden';
+    });
+
+    closeBaseModal.addEventListener('click', () => closeModal(baseModal));
+    cancelBase.addEventListener('click', () => closeModal(baseModal));
+
+    baseModal.addEventListener('click', (e) => {
+        if (e.target === baseModal) {
+            closeModal(baseModal);
+        }
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && baseModal.classList.contains('show')) {
+            closeModal(baseModal);
+        }
+    });
+
+    saveBase.addEventListener('click', () => {
+        const id = baseIdInput.value ? parseInt(baseIdInput.value) : null;
+        const name = baseNameInput.value.trim();
+        const location = baseLocationInput.value.trim();
+        const capacity = baseCapacityInput.value.trim();
+        const status = baseStatusInput.value;
+
+        if (!name || !location || !capacity) {
+            alert('Please fill in all fields');
+            return;
+        }
+
+        if (id) {
+            const index = bases.findIndex(base => base.id === id);
+            if (index !== -1) {
+                bases[index] = { id, name, location, capacity, status };
+            }
+        } else {
+            bases.push({
+                id: nextBaseId++,
+                name,
+                location,
+                capacity,
+                status
+            });
+        }
+
+        renderBases();
+        closeModal(baseModal);
+    });
+
+    // Edit base
+    function editBase(id) {
+        const base = bases.find(base => base.id === id);
+        if (base) {
+            baseModalTitle.textContent = 'Edit Base';
+            baseIdInput.value = base.id;
+            baseNameInput.value = base.name;
+            baseLocationInput.value = base.location;
+            baseCapacityInput.value = base.capacity;
+            baseStatusInput.value = base.status;
+
+            baseModal.classList.add('show');
+            document.body.style.overflow = 'hidden';
+        }
+    }
+
+    // Delete base
+    function deleteBase(id) {
+        if (confirm('Are you sure you want to delete this base?')) {
+            bases = bases.filter(base => base.id !== id);
+            renderBases();
+        }
+    }
+
+    // Render bases
+    function renderBases() {
+        baseList.innerHTML = '';
+
+        if (bases.length === 0) {
+            baseList.innerHTML = `
+                <div class="empty-state">
+                    <div class="empty-state-icon">⚓</div>
+                    <h3>No Naval Bases</h3>
+                    <p>Click "Add Base" to create your first naval base</p>
+                </div>
+            `;
+            return;
+        }
+
+        bases.forEach(base => {
+            const statusClass = getStatusClass(base.status);
+            const statusText = getStatusText(base.status);
+
+            const baseCard = document.createElement('div');
+            baseCard.className = 'base-card';
+            baseCard.innerHTML = `
+                <div class="base-card-header">
+                    <h3 class="base-name">${base.name}</h3>
+                    <div class="base-actions">
+                        <button class="btn btn-edit" data-id="${base.id}">✏️</button>
+                        <button class="btn btn-danger" data-id="${base.id}">🗑️</button>
+                    </div>
+                </div>
+                <div class="base-details">
+                    <div class="base-detail">
+                        <span class="base-detail-label">Location:</span>
+                        <span class="base-detail-value">${base.location}</span>
+                    </div>
+                    <div class="base-detail">
+                        <span class="base-detail-label">Capacity:</span>
+                        <span class="base-detail-value">${base.capacity}</span>
+                    </div>
+                    <div class="base-detail">
+                        <span class="base-detail-label">Status:</span>
+                        <span class="base-detail-value status"><span class="status-dot ${statusClass}"></span> ${statusText}</span>
+                    </div>
+                </div>
+            `;
+
+            baseList.appendChild(baseCard);
+        });
+
+        // Add event listeners to edit and delete buttons
+        document.querySelectorAll('.btn-edit').forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const id = parseInt(button.getAttribute('data-id'));
+                editBase(id);
+            });
+        });
+
+        document.querySelectorAll('.btn-danger').forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const id = parseInt(button.getAttribute('data-id'));
+                deleteBase(id);
+            });
+        });
+    }
+
+    // Helper functions for status
+    function getStatusClass(status) {
+        switch(status) {
+            case 'operational': return 'status-green';
+            case 'limited': return 'status-yellow';
+            case 'under-construction': return 'status-blue';
+            case 'decommissioned': return 'status-red';
+            default: return 'status-green';
+        }
+    }
+
+    function getStatusText(status) {
+        switch(status) {
+            case 'operational': return 'Operational';
+            case 'limited': return 'Limited Operations';
+            case 'under-construction': return 'Under Construction';
+            case 'decommissioned': return 'Decommissioned';
+            default: return 'Operational';
+        }
+    }
+
+    // Initial render
+    renderBases();
+
+    // Ship Management
+    let ships = [
+        {
+            id: 1,
+            name: "USS Gerald R. Ford",
+            class: "Aircraft Carrier",
+            hull: "CVN-78",
+            status: "active"
+        },
+        {
+            id: 2,
+            name: "USS Zumwalt",
+            class: "Destroyer",
+            hull: "DDG-1000",
+            status: "active"
+        },
+        {
+            id: 3,
+            name: "USS Virginia",
+            class: "Submarine",
+            hull: "SSN-774",
+            status: "active"
+        }
+    ];
+
+    let nextShipId = 4;
+
+    // Ship modal elements
+    const shipModal = document.getElementById('ship-modal');
+    const closeShipModal = document.getElementById('close-ship-modal');
+    const cancelShip = document.getElementById('cancel-ship');
+    const saveShip = document.getElementById('save-ship');
+    const addShipBtn = document.getElementById('add-ship-btn');
+    const shipModalTitle = document.getElementById('ship-modal-title');
+    const shipIdInput = document.getElementById('ship-id');
+    const shipNameInput = document.getElementById('ship-name');
+    const shipClassInput = document.getElementById('ship-class');
+    const shipHullInput = document.getElementById('ship-hull');
+    const shipStatusInput = document.getElementById('ship-status');
+    const shipList = document.getElementById('ship-list');
+
+    // Show add ship modal
+    addShipBtn.addEventListener('click', () => {
+        shipModalTitle.textContent = 'Add New Ship';
+        shipIdInput.value = '';
+        shipNameInput.value = '';
+        shipClassInput.value = 'Aircraft Carrier';
+        shipHullInput.value = '';
+        shipStatusInput.value = 'active';
+
+        shipModal.classList.add('show');
+        document.body.style.overflow = 'hidden';
+    });
+
+    // Close ship modal
+    closeShipModal.addEventListener('click', () => closeModal(shipModal));
+    cancelShip.addEventListener('click', () => closeModal(shipModal));
+
+    shipModal.addEventListener('click', (e) => {
+        if (e.target === shipModal) {
+            closeModal(shipModal);
+        }
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && shipModal.classList.contains('show')) {
+            closeModal(shipModal);
+        }
+    });
+
+    // Save ship
+    saveShip.addEventListener('click', () => {
+        const id = shipIdInput.value ? parseInt(shipIdInput.value) : null;
+        const name = shipNameInput.value.trim();
+        const shipClass = shipClassInput.value;
+        const hull = shipHullInput.value.trim();
+        const status = shipStatusInput.value;
+
+        if (!name || !hull) {
+            alert('Please fill in all required fields');
+            return;
+        }
+
+        if (id) {
+            // Edit existing ship
+            const index = ships.findIndex(ship => ship.id === id);
+            if (index !== -1) {
+                ships[index] = { id, name, class: shipClass, hull, status };
+            }
+        } else {
+            // Add new ship
+            ships.push({
+                id: nextShipId++,
+                name,
+                class: shipClass,
+                hull,
+                status
+            });
+        }
+
+        renderShips();
+        closeModal(shipModal);
+    });
+
+    // Edit ship
+    function editShip(id) {
+        const ship = ships.find(ship => ship.id === id);
+        if (ship) {
+            shipModalTitle.textContent = 'Edit Ship';
+            shipIdInput.value = ship.id;
+            shipNameInput.value = ship.name;
+            shipClassInput.value = ship.class;
+            shipHullInput.value = ship.hull;
+            shipStatusInput.value = ship.status;
+
+            shipModal.classList.add('show');
+            document.body.style.overflow = 'hidden';
+        }
+    }
+
+    // Delete ship
+    function deleteShip(id) {
+        if (confirm('Are you sure you want to delete this ship?')) {
+            ships = ships.filter(ship => ship.id !== id);
+            renderShips();
+        }
+    }
+
+    // Render ships
+    function renderShips() {
+        shipList.innerHTML = '';
+
+        if (ships.length === 0) {
+            shipList.innerHTML = `
+                <div class="empty-state">
+                    <div class="empty-state-icon">🚢</div>
+                    <h3>No Naval Ships</h3>
+                    <p>Click "Add Ship" to register your first naval vessel</p>
+                </div>
+            `;
+            return;
+        }
+
+        ships.forEach(ship => {
+            const statusClass = getShipStatusClass(ship.status);
+            const statusText = getShipStatusText(ship.status);
+            const classBadge = getShipClassBadge(ship.class);
+
+            const shipCard = document.createElement('div');
+            shipCard.className = 'ship-card';
+            shipCard.innerHTML = `
+                <div class="ship-card-header">
+                    <h3 class="ship-name">${ship.name}</h3>
+                    <div class="ship-actions">
+                        <button class="btn btn-edit" data-id="${ship.id}">✏️</button>
+                        <button class="btn btn-danger" data-id="${ship.id}">🗑️</button>
+                    </div>
+                </div>
+                <div class="ship-details">
+                    <div class="ship-detail">
+                        <span class="ship-detail-label">Class:</span>
+                        <span class="ship-detail-value">${classBadge}</span>
+                    </div>
+                    <div class="ship-detail">
+                        <span class="ship-detail-label">Hull Number:</span>
+                        <span class="ship-detail-value">${ship.hull}</span>
+                    </div>
+                    <div class="ship-detail">
+                        <span class="ship-detail-label">Status:</span>
+                        <span class="ship-detail-value status"><span class="status-dot ${statusClass}"></span> ${statusText}</span>
+                    </div>
+                </div>
+            `;
+
+            shipList.appendChild(shipCard);
+        });
+
+        // Add event listeners to edit and delete buttons
+        document.querySelectorAll('.btn-edit').forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const id = parseInt(button.getAttribute('data-id'));
+                editShip(id);
+            });
+        });
+
+        document.querySelectorAll('.btn-danger').forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const id = parseInt(button.getAttribute('data-id'));
+                deleteShip(id);
+            });
+        });
+    }
+
+    // Helper functions for ship status
+    function getShipStatusClass(status) {
+        switch(status) {
+            case 'active': return 'status-green';
+            case 'reserve': return 'status-yellow';
+            case 'under-construction': return 'status-blue';
+            case 'decommissioned': return 'status-red';
+            default: return 'status-green';
+        }
+    }
+
+    function getShipStatusText(status) {
+        switch(status) {
+            case 'active': return 'Active';
+            case 'reserve': return 'Reserve';
+            case 'under-construction': return 'Under Construction';
+            case 'decommissioned': return 'Decommissioned';
+            default: return 'Active';
+        }
+    }
+
+    function getShipClassBadge(shipClass) {
+        return `<span class="ship-class-badge">${shipClass}</span>`;
+    }
+
+    // Initial render for ships
+    renderShips();

--- a/src/server/nrp-site/views/layout.pug
+++ b/src/server/nrp-site/views/layout.pug
@@ -8,6 +8,7 @@ html
     meta(name="theme-color", content="#000000")
     title #{title} | GNS Admin
     link(rel="stylesheet" href="/style.css")
+    block head
   body
     div#root
       block layout-content


### PR DESCRIPTION
## Summary
- port the standalone dashboard layout, styling, and markup into the admin panel pug view so it renders identically within the app
- embed the dashboard’s interactive JavaScript logic (including logout redirect) to keep modals, tabs, and editing flows functional
- update the shared layout to allow admin pages to inject custom head content for the dashboard styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8c5a4ce948323b4f22fa611f01380