### PR TITLE
Add ship tracker map page with Leaflet

### DIFF
--- a/src/server/nrp-site/index.js
+++ b/src/server/nrp-site/index.js
@@ -107,6 +107,75 @@ app.get("/admin-panel", secured, (req, res, next) => {
   });
 });
 
+const shipLocations = [
+  {
+    name: "USS Gerald R. Ford (CVN-78)",
+    type: "Aircraft Carrier",
+    status: "on-patrol",
+    latitude: 36.97,
+    longitude: -74.32,
+    location: "Western Atlantic Ocean",
+    speed: "24 kn",
+    course: "075°",
+    updated: "14:05 UTC"
+  },
+  {
+    name: "USS Zumwalt (DDG-1000)",
+    type: "Stealth Destroyer",
+    status: "on-patrol",
+    latitude: 33.42,
+    longitude: 141.88,
+    location: "Western Pacific Ocean",
+    speed: "19 kn",
+    course: "310°",
+    updated: "13:20 UTC"
+  },
+  {
+    name: "USS John P. Murtha (LPD-26)",
+    type: "Amphibious Transport Dock",
+    status: "in-port",
+    latitude: 32.684,
+    longitude: -117.173,
+    location: "Naval Base San Diego",
+    speed: "0 kn",
+    course: "Docked",
+    updated: "11:42 UTC"
+  },
+  {
+    name: "USS Virginia (SSN-774)",
+    type: "Fast Attack Submarine",
+    status: "on-patrol",
+    latitude: 64.82,
+    longitude: 5.62,
+    location: "Norwegian Sea",
+    speed: "17 kn",
+    course: "145°",
+    updated: "15:31 UTC"
+  },
+  {
+    name: "USS Freedom (LCS-1)",
+    type: "Littoral Combat Ship",
+    status: "maintenance",
+    latitude: 27.951,
+    longitude: -82.448,
+    location: "Tampa Shipyard",
+    speed: "0 kn",
+    course: "In Drydock",
+    updated: "09:18 UTC"
+  },
+  {
+    name: "USNS Mercy (T-AH-19)",
+    type: "Hospital Ship",
+    status: "in-port",
+    latitude: 33.741,
+    longitude: -118.216,
+    location: "Port of Los Angeles",
+    speed: "0 kn",
+    course: "Docked",
+    updated: "10:56 UTC"
+  }
+];
+
 app.get("/", (req, res) => {
   if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
     return res.redirect("/admin-panel");
@@ -116,6 +185,13 @@ app.get("/", (req, res) => {
 
 app.get("/credits", (req, res) => {
   res.render("credits", { title: "Credits" });
+});
+
+app.get("/ship-tracker", secured, (req, res) => {
+  res.render("ship-tracker", {
+    title: "Fleet Operations Map",
+    shipLocations
+  });
 });
 
 /**

--- a/src/server/nrp-site/public/admin-dashboard.css
+++ b/src/server/nrp-site/public/admin-dashboard.css
@@ -609,7 +609,7 @@
             font-weight: 500;
         }
 
-        .add-base-btn, .add-ship-btn, .design-ship-btn {
+        .add-base-btn, .add-ship-btn, .design-ship-btn, .map-view-btn {
             background-color: var(--btn-primary);
             border: none;
             color: white;
@@ -637,6 +637,22 @@
 
         .design-ship-btn:hover {
             background-color: #383e47;
+        }
+
+        .map-view-btn {
+            background: linear-gradient(140deg, rgba(88, 166, 255, 0.22), rgba(88, 166, 255, 0.4));
+            border: 1px solid rgba(88, 166, 255, 0.45);
+            color: #ffffff;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 12px 24px rgba(88, 166, 255, 0.25);
+        }
+
+        .map-view-btn:hover {
+            background: linear-gradient(140deg, rgba(88, 166, 255, 0.35), rgba(88, 166, 255, 0.55));
+            border-color: rgba(88, 166, 255, 0.65);
         }
 
         .empty-state {

--- a/src/server/nrp-site/public/ship-map.css
+++ b/src/server/nrp-site/public/ship-map.css
@@ -1,0 +1,230 @@
+/* public/ship-map.css */
+
+body.ship-map-body {
+  background-color: var(--bg-dark);
+}
+
+body.ship-map-body #root {
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 48px 16px 64px;
+  background:
+    radial-gradient(120% 120% at 15% 0%, rgba(88, 166, 255, 0.12), transparent 60%),
+    radial-gradient(120% 120% at 85% 0%, rgba(35, 134, 54, 0.1), transparent 60%),
+    var(--bg-dark);
+}
+
+.ship-map-page {
+  width: 100%;
+  max-width: 1100px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.map-card {
+  position: relative;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 36px 36px 32px;
+  box-shadow: 0 36px 68px rgba(1, 4, 9, 0.58);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.map-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.map-card__title {
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.map-card__subtitle {
+  color: var(--text-secondary);
+  font-size: 0.98rem;
+}
+
+#ship-map {
+  width: 100%;
+  height: 520px;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(88, 166, 255, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(88, 166, 255, 0.12);
+}
+
+.map-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.ship-map-legend {
+  background-color: rgba(22, 27, 34, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 28px 50px rgba(1, 4, 9, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.legend-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.legend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid rgba(48, 54, 61, 0.7);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(88, 166, 255, 0.08), rgba(46, 160, 67, 0.04));
+}
+
+.legend-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(88, 166, 255, 0.16);
+}
+
+.legend-dot.status-on-patrol {
+  background-color: var(--accent-green);
+  box-shadow: 0 0 0 4px rgba(46, 160, 67, 0.25);
+}
+
+.legend-dot.status-in-port {
+  background-color: var(--accent-blue);
+  box-shadow: 0 0 0 4px rgba(88, 166, 255, 0.2);
+}
+
+.legend-dot.status-maintenance {
+  background-color: var(--accent-yellow);
+  box-shadow: 0 0 0 4px rgba(210, 153, 34, 0.25);
+}
+
+.legend-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.legend-label__title {
+  font-weight: 600;
+}
+
+.legend-label__meta {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.legend-footnote {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+#ship-map .leaflet-control-container .leaflet-control {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 22px rgba(1, 4, 9, 0.45);
+}
+
+#ship-map .leaflet-control-zoom a {
+  background-color: var(--btn-secondary);
+  border-bottom: 1px solid rgba(48, 54, 61, 0.7);
+  color: var(--text-primary);
+}
+
+#ship-map .leaflet-control-zoom a:hover {
+  background-color: rgba(88, 166, 255, 0.18);
+  color: #ffffff;
+}
+
+#ship-map .leaflet-control-attribution {
+  background-color: rgba(13, 17, 23, 0.9);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+#ship-map .leaflet-popup-content-wrapper,
+#ship-map .leaflet-popup-tip {
+  background-color: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+
+#ship-map .leaflet-popup-content {
+  margin: 12px 16px;
+  line-height: 1.4;
+}
+
+.popup-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.popup-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.popup-meta span {
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  #ship-map {
+    height: 420px;
+  }
+
+  .map-card {
+    padding: 28px;
+  }
+}
+
+@media (max-width: 640px) {
+  body.ship-map-body #root {
+    padding: 32px 12px 48px;
+  }
+
+  .map-card {
+    gap: 20px;
+  }
+
+  .map-card__title {
+    font-size: 1.6rem;
+  }
+
+  #ship-map {
+    height: 360px;
+  }
+
+  .legend-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/server/nrp-site/public/ship-map.js
+++ b/src/server/nrp-site/public/ship-map.js
@@ -1,0 +1,79 @@
+(function() {
+  function initShipMap() {
+    const mapContainer = document.getElementById("ship-map");
+    if (!mapContainer || typeof L === "undefined") {
+      return;
+    }
+
+    const rootStyles = getComputedStyle(document.documentElement);
+    const statusColors = {
+      "on-patrol": rootStyles.getPropertyValue("--accent-green").trim() || "#2ea043",
+      "in-port": rootStyles.getPropertyValue("--accent-blue").trim() || "#58a6ff",
+      maintenance: rootStyles.getPropertyValue("--accent-yellow").trim() || "#d29922"
+    };
+
+    const map = L.map(mapContainer, {
+      zoomSnap: 0.5,
+      zoomDelta: 0.5,
+      worldCopyJump: true
+    }).setView([20, 0], 2.5);
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 18,
+      attribution: "&copy; OpenStreetMap contributors"
+    }).addTo(map);
+
+    const ships = Array.isArray(window.shipLocations) ? window.shipLocations : [];
+
+    const markers = ships.map(ship => {
+      const color = statusColors[ship.status] || rootStyles.getPropertyValue("--accent-blue").trim() || "#58a6ff";
+
+      const marker = L.circleMarker([ship.latitude, ship.longitude], {
+        radius: 8,
+        color,
+        weight: 2,
+        fillColor: color,
+        fillOpacity: 0.7
+      }).addTo(map);
+
+      const popupHtml = [
+        `<div class="popup-title">${ship.name}</div>`,
+        `<div class="popup-meta">`,
+        `<span><strong>Type:</strong> ${ship.type}</span>`,
+        `<span><strong>Status:</strong> ${formatStatus(ship.status)}</span>`,
+        `<span><strong>Location:</strong> ${ship.location}</span>`,
+        `<span><strong>Speed:</strong> ${ship.speed}</span>`,
+        `<span><strong>Course:</strong> ${ship.course}</span>`,
+        `<span><strong>Report:</strong> ${ship.updated}</span>`,
+        `</div>`
+      ].join("");
+
+      marker.bindPopup(popupHtml);
+      return marker;
+    });
+
+    if (markers.length) {
+      const group = L.featureGroup(markers);
+      map.fitBounds(group.getBounds().pad(0.35));
+    }
+  }
+
+  function formatStatus(status) {
+    switch (status) {
+      case "on-patrol":
+        return "Active Patrol";
+      case "in-port":
+        return "In Port";
+      case "maintenance":
+        return "Maintenance";
+      default:
+        return status;
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initShipMap);
+  } else {
+    initShipMap();
+  }
+})();

--- a/src/server/nrp-site/views/admin-panel.pug
+++ b/src/server/nrp-site/views/admin-panel.pug
@@ -127,6 +127,9 @@ block layout-content
           a.design-ship-btn(href="", target="_blank")
             span
             |  Design Ships
+          a.map-view-btn(href="/ship-tracker")
+            span 🗺️
+            |  Fleet Map
           button#add-ship-btn.add-ship-btn
             span +
             |  Add Ship

--- a/src/server/nrp-site/views/ship-tracker.pug
+++ b/src/server/nrp-site/views/ship-tracker.pug
@@ -1,0 +1,48 @@
+extends layout
+
+block variables
+  - var bodyClass = 'ship-map-body'
+
+block extra_styles
+  link(rel="stylesheet", href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css", integrity="sha512-sA+e2atFlL8EJx1YgnSUZXoqBYwygJyI072QtdgQXl3k5ufADGWEcRrHBM1wYyM1Kzb0YhgrXLI4h2H2yx0Pg==", crossorigin="")
+  link(rel="stylesheet", href="/ship-map.css")
+
+block layout-content
+  main.ship-map-page
+    section.map-card
+      header.map-card__header
+        h1.map-card__title Fleet Operations Map
+        p.map-card__subtitle Monitor priority assets and their latest reported positions across the globe.
+      #ship-map
+      footer.map-card__footer
+        span.map-card__footnote Updated from aggregated fleet telemetry snapshots.
+    - const statusCounts = shipLocations.reduce((acc, ship) => {
+    -   const key = ship.status;
+    -   acc[key] = (acc[key] || 0) + 1;
+    -   return acc;
+    - }, {});
+    section.ship-map-legend
+      h2.legend-title Fleet Snapshot
+      .legend-grid
+        .legend-item
+          span.legend-dot.status-on-patrol
+          .legend-label
+            span.legend-label__title Active Patrol
+            span.legend-label__meta #{statusCounts['on-patrol'] || 0} ships underway
+        .legend-item
+          span.legend-dot.status-in-port
+          .legend-label
+            span.legend-label__title In Port
+            span.legend-label__meta #{statusCounts['in-port'] || 0} ships docked
+        .legend-item
+          span.legend-dot.status-maintenance
+          .legend-label
+            span.legend-label__title Maintenance
+            span.legend-label__meta #{statusCounts['maintenance'] || 0} ships in refit
+      p.legend-footnote Ship positions are representative training data for visualization purposes.
+
+block scripts
+  script(src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js", integrity="sha512-1w2n+1sBCphPmS4GNzcRCjSc5MiNmiY6LHlH944sW1YHlzTH0PzZMfjNV8iPBUFeCFGXFqPbj0z2D2Go+ZtZAQ==", crossorigin="")
+  script.
+    window.shipLocations = !{JSON.stringify(shipLocations)};
+  script(src="/ship-map.js")

--- a/src/server/nrp-site/views/ship-tracker.pug
+++ b/src/server/nrp-site/views/ship-tracker.pug
@@ -4,7 +4,7 @@ block variables
   - var bodyClass = 'ship-map-body'
 
 block extra_styles
-  link(rel="stylesheet", href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css", integrity="sha512-sA+e2atFlL8EJx1YgnSUZXoqBYwygJyI072QtdgQXl3k5ufADGWEcRrHBM1wYyM1Kzb0YhgrXLI4h2H2yx0Pg==", crossorigin="")
+  link(rel="stylesheet", href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css", integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=", crossorigin="")
   link(rel="stylesheet", href="/ship-map.css")
 
 block layout-content
@@ -42,7 +42,7 @@ block layout-content
       p.legend-footnote Ship positions are representative training data for visualization purposes.
 
 block scripts
-  script(src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js", integrity="sha512-1w2n+1sBCphPmS4GNzcRCjSc5MiNmiY6LHlH944sW1YHlzTH0PzZMfjNV8iPBUFeCFGXFqPbj0z2D2Go+ZtZAQ==", crossorigin="")
+  script(src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js", integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=", crossorigin="")
   script.
     window.shipLocations = !{JSON.stringify(shipLocations)};
   script(src="/ship-map.js")


### PR DESCRIPTION
## Summary
- add a secured `/ship-tracker` route that serves sample fleet position data and link it from the admin panel
- build a Leaflet-powered ship tracker view with a fleet status legend styled to match the existing theme
- add dedicated styles and scripts for the map experience and adjust dashboard styles for the new navigation button

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cab6b68b388323a8bbd4b903708308