### PR TITLE
Fix ship overlay popup formatting

### DIFF
--- a/src/server/nrp-site/public/ship-map.css
+++ b/src/server/nrp-site/public/ship-map.css
@@ -194,7 +194,9 @@ body.ship-map-body #root {
 }
 
 .popup-meta span {
-  white-space: nowrap;
+  min-width: 0;
+  white-space: normal;
+  display: block;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- allow popup details to wrap inside the grid by letting the grid items shrink
- ensure ship popups display each field cleanly in their column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cad6e594948323ab2b1cd25eb7a185