### PR TITLE
Enable reverse proxy support

### DIFF
--- a/src/server/nrp-site/auth.js
+++ b/src/server/nrp-site/auth.js
@@ -59,15 +59,9 @@ router.get("/logout", (req, res, next) => {
       return next(err);
     }
 
-    let returnTo = req.protocol + "://" + req.hostname;
-    const port = req.connection.localPort;
-
-    if (port !== undefined && port !== 80 && port !== 443) {
-      returnTo =
-        process.env.NODE_ENV === "production"
-          ? `${returnTo}/`
-          : `${returnTo}:${port}/`;
-    }
+    const host = req.get("host");
+    const baseUrl = new URL("/", `${req.protocol}://${host}`);
+    const returnTo = baseUrl.toString();
 
     const logoutURL = new URL(
       `https://${process.env.AUTH0_DOMAIN}/v2/logout`

--- a/src/server/nrp-site/index.js
+++ b/src/server/nrp-site/index.js
@@ -19,6 +19,21 @@ const authRouter = require("./auth");
  */
 const app = express();
 const port = process.env.PORT || "8000";
+const host = process.env.HOST || "0.0.0.0";
+
+const trustProxy = process.env.TRUST_PROXY;
+if (trustProxy) {
+  const normalized = trustProxy.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1") {
+    app.set("trust proxy", 1);
+  } else if (normalized === "false" || normalized === "0") {
+    app.set("trust proxy", false);
+  } else {
+    app.set("trust proxy", trustProxy);
+  }
+} else if (app.get("env") === "production") {
+  app.set("trust proxy", 1);
+}
 
 /**
  * Session Configuration
@@ -31,9 +46,10 @@ const session = {
   saveUninitialized: false
 };
 
-if (app.get("env") === "production") {
-  // Serve secure cookies, requires HTTPS
-  session.cookie.secure = false;
+if (app.get("env") === "production" && app.get("trust proxy")) {
+  // Serve secure cookies behind HTTPS (including reverse proxies)
+  session.cookie.secure = true;
+  session.cookie.sameSite = "lax";
 }
 
 /**
@@ -197,6 +213,6 @@ app.get("/ship-tracker", secured, (req, res) => {
 /**
  * Server Activation
  */
-app.listen(port, () => {
-  console.log(`Listening to requests on http://localhost:${port}`);
+app.listen(port, host, () => {
+  console.log(`Listening to requests on ${host}:${port}`);
 });


### PR DESCRIPTION
## Summary
- allow configuring the Express server host and trust proxy behavior for reverse proxy deployments
- enable secure session cookies when running behind HTTPS and a trusted proxy
- build logout redirect URLs from forwarded host headers so Auth0 callbacks work through nginx

## Testing
- `node index.js` *(fails: missing Auth0 configuration values in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccaf75912c8323ad54e87b7d4a778a