### PR TITLE
Ensure container runs when /app is bind-mounted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.11-slim
 
 ENV PIP_NO_CACHE_DIR=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    APP_HOME=/opt/nrp-site
 
 # Install Node.js and system dependencies
 RUN apt-get update \
@@ -16,24 +17,24 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove curl gnupg \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+WORKDIR ${APP_HOME}
 
 # Install Python dependencies
 COPY src/server/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install Node dependencies for the Express app
-WORKDIR /app/src/server/nrp-site
+WORKDIR ${APP_HOME}/src/server/nrp-site
 COPY src/server/nrp-site/package*.json ./
 RUN npm install
 
 # Copy the rest of the application source
-WORKDIR /app
+WORKDIR ${APP_HOME}
 COPY src ./src
 
-WORKDIR /app/src/server
+WORKDIR ${APP_HOME}/src/server
 
 # Expose the ports used by the Express server and BrowserSync proxy
-EXPOSE 3000 3001
+EXPOSE 3000 3001 8000
 
-CMD ["python", "server_launcher.py"]
+CMD ["python", "/opt/nrp-site/src/server/server_launcher.py"]

--- a/src/server/nrp-site/auth.js
+++ b/src/server/nrp-site/auth.js
@@ -10,29 +10,89 @@ const querystring = require("querystring");
 
 require("dotenv").config();
 
+const PUBLIC_URL = process.env.PUBLIC_URL && process.env.PUBLIC_URL.trim();
+
+const forwardedValue = (value) => {
+  if (!value) {
+    return undefined;
+  }
+  return value.split(",")[0].trim();
+};
+
+const ensureLeadingSlash = (value) => {
+  if (!value.startsWith("/")) {
+    return `/${value}`;
+  }
+  return value;
+};
+
+const ensureTrailingSlash = (value) => {
+  if (!value.endsWith("/")) {
+    return `${value}/`;
+  }
+  return value;
+};
+
+const resolvePublicBaseUrl = (req) => {
+  let base;
+
+  if (PUBLIC_URL) {
+    try {
+      base = new URL(PUBLIC_URL);
+    } catch (error) {
+      console.warn("Invalid PUBLIC_URL provided; falling back to request data.");
+    }
+  }
+
+  if (!base) {
+    const host =
+      forwardedValue(req.headers["x-forwarded-host"]) || req.get("host");
+    const protocol =
+      forwardedValue(req.headers["x-forwarded-proto"]) || req.protocol || "http";
+
+    base = new URL(`${protocol}://${host || "localhost"}`);
+
+    const prefix = forwardedValue(req.headers["x-forwarded-prefix"]);
+    if (prefix) {
+      base.pathname = ensureLeadingSlash(ensureTrailingSlash(prefix));
+    }
+  }
+
+  base.pathname = ensureTrailingSlash(base.pathname);
+
+  return base;
+};
+
+const buildPublicUrl = (req, pathname) => {
+  const base = resolvePublicBaseUrl(req);
+  if (typeof pathname === "string") {
+    return new URL(pathname, base);
+  }
+  return new URL(base.toString());
+};
+
 /**
  * Routes Definitions
  */
-router.get(
-  "/login",
-  (req, res, next) => {
-    if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
-      return res.redirect("/admin-panel");
-    }
-
-    if (req.session) {
-      req.session.returnTo = "/admin-panel";
-    }
-
-    next();
-  },
-  passport.authenticate("auth0", {
-    scope: "openid email profile"
-  }),
-  (req, res) => {
-    res.redirect("/admin-panel");
+router.get("/login", (req, res, next) => {
+  if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
+    return res.redirect("/admin-panel");
   }
-);
+
+  if (req.session) {
+    req.session.returnTo = "/admin-panel";
+  }
+
+  const authOptions = {
+    scope: "openid email profile"
+  };
+
+  if (!process.env.AUTH0_CALLBACK_URL) {
+    authOptions.callbackURL = buildPublicUrl(req, "callback").toString();
+  }
+
+  return passport.authenticate("auth0", authOptions)(req, res, next);
+});
 
 router.get("/callback", (req, res, next) => {
   passport.authenticate("auth0", (err, user, info) => {
@@ -59,15 +119,7 @@ router.get("/logout", (req, res, next) => {
       return next(err);
     }
 
-    let returnTo = req.protocol + "://" + req.hostname;
-    const port = req.connection.localPort;
-
-    if (port !== undefined && port !== 80 && port !== 443) {
-      returnTo =
-        process.env.NODE_ENV === "production"
-          ? `${returnTo}/`
-          : `${returnTo}:${port}/`;
-    }
+    const returnTo = buildPublicUrl(req).toString();
 
     const logoutURL = new URL(
       `https://${process.env.AUTH0_DOMAIN}/v2/logout`


### PR DESCRIPTION
## Summary
- install the application under /opt/nrp-site so bind-mounting /app no longer hides the runtime files
- expose port 8000 alongside the development ports and invoke the launcher via an absolute path
- introduce an APP_HOME variable to centralize the installation prefix throughout the Dockerfile
- derive Auth0 callback and logout URLs from proxy-aware host information so the sign-in flow returns to the public domain when running behind nginx

## Testing
- `docker build -t nrp-site-test .` *(fails: docker CLI is unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccaf75912c8323ad54e87b7d4a778a