### PR TITLE
Add base path aware routing for reverse proxy deployments

### DIFF
--- a/src/server/nrp-site/auth.js
+++ b/src/server/nrp-site/auth.js
@@ -4,81 +4,86 @@
  * Required External Modules
  */
 const express = require("express");
-const router = express.Router();
 const passport = require("passport");
 const querystring = require("querystring");
 
 require("dotenv").config();
 
-/**
- * Routes Definitions
- */
-router.get(
-  "/login",
-  (req, res, next) => {
-    if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
-      return res.redirect("/admin-panel");
-    }
+const defaultApplyBasePath = (pathname = "/") =>
+  pathname.startsWith("/") ? pathname : `/${pathname}`;
 
-    if (req.session) {
-      req.session.returnTo = "/admin-panel";
-    }
+const createAuthRouter = ({ applyBasePath = defaultApplyBasePath } = {}) => {
+  const router = express.Router();
 
-    next();
-  },
-  passport.authenticate("auth0", {
-    scope: "openid email profile"
-  }),
-  (req, res) => {
-    res.redirect("/admin-panel");
-  }
-);
+  router.get(
+    "/login",
+    (req, res, next) => {
+      if (typeof req.isAuthenticated === "function" && req.isAuthenticated()) {
+        return res.redirect(applyBasePath("/admin-panel"));
+      }
 
-router.get("/callback", (req, res, next) => {
-  passport.authenticate("auth0", (err, user, info) => {
-    if (err) {
-      return next(err);
+      if (req.session) {
+        req.session.returnTo = applyBasePath("/admin-panel");
+      }
+
+      next();
+    },
+    passport.authenticate("auth0", {
+      scope: "openid email profile"
+    }),
+    (req, res) => {
+      res.redirect(applyBasePath("/admin-panel"));
     }
-    if (!user) {
-      return res.redirect("/login");
-    }
-    req.logIn(user, (err) => {
+  );
+
+  router.get("/callback", (req, res, next) => {
+    passport.authenticate("auth0", (err, user, info) => {
       if (err) {
         return next(err);
       }
-      const returnTo = req.session.returnTo;
-      delete req.session.returnTo;
-      res.redirect(returnTo || "/admin-panel");
-    });
-  })(req, res, next);
-});
-
-router.get("/logout", (req, res, next) => {
-  req.logOut((err) => {
-    if (err) {
-      return next(err);
-    }
-
-    const host = req.get("host");
-    const baseUrl = new URL("/", `${req.protocol}://${host}`);
-    const returnTo = baseUrl.toString();
-
-    const logoutURL = new URL(
-      `https://${process.env.AUTH0_DOMAIN}/v2/logout`
-    );
-
-    const searchString = querystring.stringify({
-      client_id: process.env.AUTH0_CLIENT_ID,
-      returnTo: returnTo
-    });
-    logoutURL.search = searchString;
-
-    res.redirect(logoutURL);
+      if (!user) {
+        return res.redirect(applyBasePath("/login"));
+      }
+      req.logIn(user, (err) => {
+        if (err) {
+          return next(err);
+        }
+        const returnTo = req.session.returnTo;
+        delete req.session.returnTo;
+        res.redirect(returnTo || applyBasePath("/admin-panel"));
+      });
+    })(req, res, next);
   });
-});
 
+  router.get("/logout", (req, res, next) => {
+    req.logOut((err) => {
+      if (err) {
+        return next(err);
+      }
 
-/**
- * Module Exports
- */
-module.exports = router;
+      const host = req.get("host");
+      const protocol = req.protocol || "http";
+      const returnToPath = applyBasePath("/") || "/";
+      const baseUrl = host
+        ? new URL(returnToPath || "/", `${protocol}://${host}`)
+        : null;
+      const returnTo = baseUrl ? baseUrl.toString() : returnToPath || "/";
+
+      const logoutURL = new URL(
+        `https://${process.env.AUTH0_DOMAIN}/v2/logout`
+      );
+
+      const searchString = querystring.stringify({
+        client_id: process.env.AUTH0_CLIENT_ID,
+        returnTo
+      });
+      logoutURL.search = searchString;
+
+      res.redirect(logoutURL);
+    });
+  });
+
+  return router;
+};
+
+module.exports = createAuthRouter;

--- a/src/server/nrp-site/views/admin-panel.pug
+++ b/src/server/nrp-site/views/admin-panel.pug
@@ -6,7 +6,7 @@ block variables
   - var bodyClass = 'admin-dashboard'
 
 block extra_styles
-  link(rel="stylesheet", href="/admin-dashboard.css")
+  link(rel="stylesheet", href=applyBasePath('/admin-dashboard.css'))
 
 block layout-content
   aside#sidebar.sidebar
@@ -54,7 +54,7 @@ block layout-content
         .tab.active(data-tab="ships") Ships
         .tab(data-tab="fleets") Fleets
       .user-menu
-        a.sign-out-btn(href="/logout")
+        a.sign-out-btn(href=applyBasePath('/logout'))
           span 🚪
           |  Sign Out
   main.main-content
@@ -127,7 +127,7 @@ block layout-content
           a.design-ship-btn(href="", target="_blank")
             span
             |  Design Ships
-          a.map-view-btn(href="/ship-tracker")
+          a.map-view-btn(href=applyBasePath('/ship-tracker'))
             span 🗺️
             |  Fleet Map
           button#add-ship-btn.add-ship-btn
@@ -330,4 +330,4 @@ block layout-content
         button#save-ship.btn.btn-primary Save Ship
 
 block scripts
-  script(src="/admin-dashboard.js")
+  script(src=applyBasePath('/admin-dashboard.js'))

--- a/src/server/nrp-site/views/credits.pug
+++ b/src/server/nrp-site/views/credits.pug
@@ -4,7 +4,7 @@ block layout-content
   main.credits-page
     section.credits-card
       nav.credits-nav
-        a.credits-back(href="/")
+        a.credits-back(href=applyBasePath('/'))
           span.credits-back-icon &larr;
           span Back to login
       header.credits-header

--- a/src/server/nrp-site/views/index.pug
+++ b/src/server/nrp-site/views/index.pug
@@ -5,7 +5,7 @@ block layout-content
     section.login-card
       h1.login-logo GMS Admin
       h2.login-title GeoFS NRP Admin Site
-      a.login-button(href="/login") Log in
+      a.login-button(href=applyBasePath('/login')) Log in
       p.login-details For High Command officers and centralized governing members
       footer.login-meta
-        a.login-credits-link(href="/credits") View project credits
+        a.login-credits-link(href=applyBasePath('/credits')) View project credits

--- a/src/server/nrp-site/views/layout.pug
+++ b/src/server/nrp-site/views/layout.pug
@@ -8,12 +8,12 @@ doctype html
 html
   head
     meta(charset="utf-8")
-    link(rel="shortcut icon", href="/favicon.ico")
+    link(rel="shortcut icon", href=applyBasePath('/favicon.ico'))
     meta(name="viewport", content="width=device-width, initial-scale=1, shrink-to-fit=no")
     meta(name="theme-color", content="#000000")
     title #{title} | GNS Admin
     if includeBaseStyles
-      link(rel="stylesheet", href="/style.css")
+      link(rel="stylesheet", href=applyBasePath('/style.css'))
     block extra_styles
   body(class=bodyClass || undefined)
     if useRootContainer

--- a/src/server/nrp-site/views/ship-tracker.pug
+++ b/src/server/nrp-site/views/ship-tracker.pug
@@ -5,7 +5,7 @@ block variables
 
 block extra_styles
   link(rel="stylesheet", href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css", integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=", crossorigin="")
-  link(rel="stylesheet", href="/ship-map.css")
+  link(rel="stylesheet", href=applyBasePath('/ship-map.css'))
 
 block layout-content
   main.ship-map-page
@@ -45,4 +45,4 @@ block scripts
   script(src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js", integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=", crossorigin="")
   script.
     window.shipLocations = !{JSON.stringify(shipLocations)};
-  script(src="/ship-map.js")
+  script(src=applyBasePath('/ship-map.js'))


### PR DESCRIPTION
## Summary
- add helpers to derive a configurable base path and expose it to routes and templates
- update Auth0 routing and redirects to honor the computed base path
- adjust template asset and navigation links to use the shared helper so they work behind reverse proxies

## Testing
- node -e "require('./src/server/nrp-site/auth.js')({ applyBasePath: (p) => p })"


------
https://chatgpt.com/codex/tasks/task_e_68ccbb4e60f48323819a508b4d6f52cf