### PR TITLE
Implement Auth0-compliant logout flow

### DIFF
--- a/src/server/nrp-site/index.js
+++ b/src/server/nrp-site/index.js
@@ -159,7 +159,9 @@ app.use((req, res, next) => {
   next();
 });
 
-const authRouter = createAuthRouter({ applyBasePath });
+const { router: authRouter, getLogoutReturnTo } = createAuthRouter({
+  applyBasePath
+});
 
 app.use(basePath || "/", authRouter);
 
@@ -180,7 +182,8 @@ router.get("/admin-panel", secured, (req, res, next) => {
   const { _raw, _json, ...userProfile } = req.user;
   res.render("admin-panel", {
     title: "Admin Panel",
-    userProfile: userProfile
+    userProfile: userProfile,
+    logoutReturnTo: getLogoutReturnTo(req)
   });
 });
 

--- a/src/server/nrp-site/public/admin-dashboard.js
+++ b/src/server/nrp-site/public/admin-dashboard.js
@@ -14,6 +14,26 @@ const applyBasePath = (pathname = '/') => {
 
     return `${basePath}${normalized}`.replace(/\/{2,}/g, '/');
 };
+const attachSignOutHandler = () => {
+    const button = $('.sign-out-btn');
+    if (!button) {
+        return;
+    }
+
+    button.addEventListener('click', () => {
+        const params = new URLSearchParams();
+        const returnTo = (button.dataset.logoutReturnTo || '').trim();
+        if (returnTo) {
+            params.set('returnTo', returnTo);
+        }
+
+        const logoutPath = applyBasePath('/logout');
+        const query = params.toString();
+        const targetUrl = query ? `${logoutPath}?${query}` : logoutPath;
+        window.location.assign(targetUrl);
+    });
+};
+attachSignOutHandler();
 class Modal {
     constructor(el, closeBtns = []) {
         this.el = el;

--- a/src/server/nrp-site/views/admin-panel.pug
+++ b/src/server/nrp-site/views/admin-panel.pug
@@ -53,7 +53,7 @@ block layout-content
         a.ship-tracker-btn(href=applyBasePath('/ship-tracker'), target='_blank', rel='noopener')
           span.material-symbols-outlined map
           |  Ship Tracker
-        button.sign-out-btn(type='button', data-logout-return-to=absoluteUrl('/'))
+        button.sign-out-btn(type='button', data-logout-return-to=logoutReturnTo)
           span
           |  Sign Out
   main.main-content

--- a/src/server/nrp-site/views/admin-panel.pug
+++ b/src/server/nrp-site/views/admin-panel.pug
@@ -53,7 +53,7 @@ block layout-content
         a.ship-tracker-btn(href=applyBasePath('/ship-tracker'), target='_blank', rel='noopener')
           span.material-symbols-outlined map
           |  Ship Tracker
-        button.sign-out-btn(type='button')
+        button.sign-out-btn(type='button', data-logout-return-to=absoluteUrl('/'))
           span
           |  Sign Out
   main.main-content


### PR DESCRIPTION
## Summary
- wire the dashboard sign-out control to call the server-side logout endpoint with the saved login target
- update the Auth0 logout route to honour a validated returnTo query string while falling back to the login page
- embed the login URL into the sign-out button markup so the client can pass it through the logout request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0c6ee73388323b80b329584e15d51